### PR TITLE
add optional callback for RoktWidget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
-## 0.0.1
+## 3.6.0
 
 * Introducing Rokt flutter SDK

--- a/README.md
+++ b/README.md
@@ -89,7 +89,10 @@ To run an placement in the sandbox environment, the list of attributes passed to
 ### add Rokt Widget
 
 add `const RoktWidget(placeholderName: "RoktEmbedded1")` in your view.
-please make sure that the view is created on visible area of the screen and then call showWidget
+please make sure that the view is created on the visible area of the screen and then call showWidget.
+RoktWidget has a callback to notify when widget is created which could be utilized.
+`RoktWidget(placeholderName: "RoktEmbedded1", onWidgetCreated: () { showWidget() })`
+
 ### Execute Rokt
 ```
 import 'package:rokt_sdk/rokt_sdk.dart';

--- a/README.md
+++ b/README.md
@@ -123,3 +123,19 @@ void showWidget() {
 ```
 
 To run an placement in the sandbox environment, the list of attributes passed to Rokt needs to be updated to include `"sandbox": "true"`
+
+## How to run the example app locally
+- Open project in Android Studio for changing the code
+- run following commands in terminal or equalivant in Android Studio
+- run `flutter clean`
+- run `flutter pub get`
+- run `flutter run`
+
+## License
+```
+Copyright 2020 Rokt Pte Ltd
+
+Licensed under the Rokt Software Development Kit (SDK) Terms of Use
+Version 2.0 (the "License");
+
+You may not use this file except in compliance with the License.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -51,5 +51,5 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation "com.rokt:roktsdk:3.6.3"
+    implementation "com.rokt:roktsdk:3.6.4"
 }

--- a/example/README.md
+++ b/example/README.md
@@ -1,16 +1,19 @@
 # rokt_sdk_example
 
-Demonstrates how to use the rokt_sdk plugin.
+Rokt SDK Example application is a sample app built to showcase Rokt SDK functionality.
 
-## Getting Started
+## How to run locally
+- Open project in Android Studio for changing the code
+- run following commands in terminal or equalivant in Android Studio
+- run `flutter clean`
+- run `flutter pub get`
+- run `flutter run`
 
-This project is a starting point for a Flutter application.
+## License
+```
+Copyright 2020 Rokt Pte Ltd
 
-A few resources to get you started if this is your first Flutter project:
+Licensed under the Rokt Software Development Kit (SDK) Terms of Use
+Version 2.0 (the "License");
 
-- [Lab: Write your first Flutter app](https://flutter.dev/docs/get-started/codelab)
-- [Cookbook: Useful Flutter samples](https://flutter.dev/docs/cookbook)
-
-For help getting started with Flutter, view our
-[online documentation](https://flutter.dev/docs), which offers tutorials,
-samples, guidance on mobile development, and a full API reference.
+You may not use this file except in compliance with the License.

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -102,7 +102,11 @@ class _MyAppState extends State<MyApp> {
                         const Text("Location 1"),
                         const RoktWidget(placeholderName: "Location1"),
                         const Text("Location 2"),
-                        const RoktWidget(placeholderName: "Location2"),
+                        RoktWidget(placeholderName: "Location2",
+                            onWidgetCreated: () {
+                            debugPrint(
+                              "rokt_widget widget is created");
+                            }),
                         const Text("The end")
                       ],
                     ),

--- a/ios/rokt_sdk.podspec
+++ b/ios/rokt_sdk.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'rokt_sdk'
-  s.version          = '0.0.1'
+  s.version          = '3.6.0'
   s.summary          = 'Rokt Mobile SDK to integrate ROKT Api into Flutter application'
   s.description      = <<-DESC
 A new flutter plugin project.

--- a/ios/rokt_sdk.podspec
+++ b/ios/rokt_sdk.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
   s.version          = '3.6.0'
   s.summary          = 'Rokt Mobile SDK to integrate ROKT Api into Flutter application'
   s.description      = <<-DESC
-A new flutter plugin project.
+Rokt Mobile SDK to integrate ROKT Api into Flutter application.
                        DESC
   s.homepage         = 'https://docs.rokt.com/docs/developers/integration-guides/flutter/overview'
   s.license          = { :file => '../LICENSE' }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: rokt_sdk
 description: Rokt Mobile SDK to integrate ROKT Api into flutter applications.
-version: 0.0.1
+version: 3.6.0
 homepage: https://github.com/ROKT/rokt-sdk-flutter
 
 environment:


### PR DESCRIPTION
### Background ###

RoktWidget didn't notify the application when the widget is created

### What Has Changed: ###

onWidgetCreated callback added to RoktWidget to notify the application when the View is ready

### Checklist: ###

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have verified that CI completes successfully.
- [x] All insignificant commits have been squashed.