### PR TITLE
MP-2830 - Receive partner fonts in the flutter SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.1.0
+* Release 4.1.0 stable SDK
+
 ## 4.0.0-alpha.3
 * Introduces Layouts
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -51,5 +51,5 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation "com.rokt:roktsdk:4.1.0-beta.1"
+    implementation "com.rokt:roktsdk:4.1.1-alpha.1"
 }

--- a/android/src/main/kotlin/com/rokt/rokt_sdk/RoktSdkPlugin.kt
+++ b/android/src/main/kotlin/com/rokt/rokt_sdk/RoktSdkPlugin.kt
@@ -1,14 +1,17 @@
 package com.rokt.rokt_sdk
 
+import android.graphics.Typeface
 import androidx.annotation.NonNull
 import io.flutter.embedding.engine.plugins.FlutterPlugin
+import io.flutter.embedding.engine.plugins.FlutterPlugin.FlutterAssets
 import io.flutter.embedding.engine.plugins.activity.ActivityAware
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
 import io.flutter.plugin.common.BinaryMessenger
+import io.flutter.plugin.common.PluginRegistry
 
 
 /** RoktSdkPlugin */
-class RoktSdkPlugin: FlutterPlugin, ActivityAware {
+class RoktSdkPlugin : FlutterPlugin, ActivityAware {
     private var methodCallHandler: MethodCallHandlerImpl? = null
 
     override fun onAttachedToEngine(@NonNull flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
@@ -16,7 +19,11 @@ class RoktSdkPlugin: FlutterPlugin, ActivityAware {
         flutterPluginBinding.platformViewRegistry.registerViewFactory(
             VIEW_TYPE, widgetFactory
         )
-        setupMethodChannel(flutterPluginBinding.binaryMessenger, widgetFactory)
+        setupMethodChannel(
+            flutterPluginBinding.binaryMessenger,
+            flutterPluginBinding.flutterAssets,
+            widgetFactory
+        )
     }
 
     override fun onDetachedFromEngine(@NonNull binding: FlutterPlugin.FlutterPluginBinding) {
@@ -36,8 +43,12 @@ class RoktSdkPlugin: FlutterPlugin, ActivityAware {
     override fun onDetachedFromActivity() {
     }
 
-    private fun setupMethodChannel(messenger: BinaryMessenger, widgetFactory: RoktWidgetFactory) {
-        methodCallHandler = MethodCallHandlerImpl(messenger, widgetFactory)
+    private fun setupMethodChannel(
+        messenger: BinaryMessenger,
+        flutterAssets: FlutterAssets,
+        widgetFactory: RoktWidgetFactory
+    ) {
+        methodCallHandler = MethodCallHandlerImpl(messenger, flutterAssets, widgetFactory)
     }
 
     private fun teardownMethodChannel() {

--- a/ios/Classes/SwiftRoktSdkPlugin.swift
+++ b/ios/Classes/SwiftRoktSdkPlugin.swift
@@ -23,22 +23,24 @@ public class SwiftRoktSdkPlugin: NSObject, FlutterPlugin {
     
     let channel: FlutterMethodChannel
     let factory: RoktWidgetFactory
+    let registrar: FlutterPluginRegistrar
     
-    init(channel: FlutterMethodChannel, factory: RoktWidgetFactory) {
+    init(channel: FlutterMethodChannel, factory: RoktWidgetFactory, registrar: FlutterPluginRegistrar) {
         self.channel = channel
         self.factory = factory
+        self.registrar = registrar
     }
     
     public static func register(with registrar: FlutterPluginRegistrar) {
         let channel = FlutterMethodChannel(name: CHANNEL_NAME, binaryMessenger: registrar.messenger())
         let factory = RoktWidgetFactory(messenger: registrar.messenger())
-        let instance = SwiftRoktSdkPlugin(channel: channel, factory: factory)
+        let instance = SwiftRoktSdkPlugin(channel: channel, factory: factory, registrar: registrar)
         registrar.addMethodCallDelegate(instance, channel: channel)
         registrar.register(factory, withId: VIEW_CALL_DELEGATE)
     }
     
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
-        let handler = RoktMethodCallHandler(channel: channel, factory: factory)
+        let handler = RoktMethodCallHandler(channel: channel, factory: factory, registrar: registrar)
         if call.method == INIT_METHOD {
             handler.initialize(call, result: result)
         } else if call.method == EXECUTE_METHOD {

--- a/ios/rokt_sdk.podspec
+++ b/ios/rokt_sdk.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'rokt_sdk'
-  s.version          = '4.1.0-beta.1'
+  s.version          = '4.1.0'
   s.summary          = 'Rokt Mobile SDK to integrate ROKT Api into Flutter application'
   s.description      = <<-DESC
 Rokt Mobile SDK to integrate ROKT Api into Flutter application.
@@ -15,7 +15,7 @@ Rokt Mobile SDK to integrate ROKT Api into Flutter application.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Rokt-Widget', '~> 4.1.0-beta.1'
+  s.dependency 'Rokt-Widget', '~> 4.1.0'
   s.platform = :ios, '10.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/lib/rokt_sdk.dart
+++ b/lib/rokt_sdk.dart
@@ -65,10 +65,14 @@ class RoktSdk {
   /// The recommended way of calling the initialize method is early in the application.
   /// - Parameters:
   ///   - roktTagId: The tag id provided by Rokt, associated with your account.
+  ///   - appVersion: App version string
+  ///   - fontFilePathMap: Optional. A map of custom font postscript name to font file. Eg: "Arial-bold": "fonts/Arial-Bold.ttf"
   static Future<void> initialize(String roktTagId,
-      {String appVersion = ''}) async {
+      {String appVersion = '', Map<String, String> fontFilePathMap = const {}}) async {
     await RoktSdkController.instance
-        .initialize(roktTagId: roktTagId, appVersion: appVersion);
+        .initialize(roktTagId: roktTagId,
+        appVersion: appVersion,
+        fontFilePathMap: fontFilePathMap);
   }
 
   /// Execute Rokt widget
@@ -90,7 +94,7 @@ class RoktSdk {
     RoktCallback onLoad = _defaultRoktCallBack,
     RoktCallback onUnLoad = _defaultRoktCallBack,
     RoktCallback onShouldShowLoadingIndicator = _defaultRoktCallBack,
-    RoktCallback onShouldHideLoadingIndicator = _defaultRoktCallBack,
+    RoktCallback onShouldHideLoadingIndicator = _defaultRoktCallBack
   }) async {
     _onLoad = onLoad;
     _onUnLoad = onUnLoad;

--- a/lib/src/rokt_sdk_controller.dart
+++ b/lib/src/rokt_sdk_controller.dart
@@ -25,9 +25,9 @@ class RoktSdkController {
 
   /// Call Rokt Initialize method in Native SDK
   Future<void> initialize(
-      {required String roktTagId, String appVersion = ''}) async {
+      {required String roktTagId, String appVersion = '', Map<String, String> fontFilePathMap = const {}}) async {
     await _channel.invokeMethod(
-        'initialize', {'roktTagId': roktTagId, 'appVersion': appVersion});
+        'initialize', {'roktTagId': roktTagId, 'appVersion': appVersion, 'fontFilePathMap': fontFilePathMap});
   }
 
   /// Call Rokt Execute method in Native SDK
@@ -41,7 +41,7 @@ class RoktSdkController {
       'viewName': viewName,
       'attributes': attributes,
       'placeholders': instance._placeholders,
-      'callbackId': currentCallbackId
+      'callbackId': currentCallbackId,
     });
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: rokt_sdk
 description: Rokt Mobile SDK to integrate ROKT Api into flutter applications.
-version: 4.0.0-alpha.3
+version: 4.1.0
 homepage: https://github.com/ROKT/rokt-sdk-flutter
 
 environment:


### PR DESCRIPTION
### Background ###

* Accept the partner font map as an optional parameter and pass it to the native bridge
* On Android translate the flutter path to asset font path and pass it to the native `init`
* On iOS use the `lookupKey` API to find the font file from the bundle and use `CTFontManagerRegisterFontsForURL` API to register the font.

Fixes [MP-2830](https://rokt.atlassian.net/browse/MP-2830)

### What Has Changed: ###

Adding an optional parameter to receive partner fonts

### How Has This Been Tested? ###

Tested locally

### Checklist: ###

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have verified that CI completes successfully.
- [x] All insignificant commits have been squashed.