### PR TITLE
Fix iOS embedded flicker

### DIFF
--- a/lib/src/rokt_widget.dart
+++ b/lib/src/rokt_widget.dart
@@ -67,7 +67,7 @@ class _RoktContainerState extends State<RoktWidget>
   Widget build(BuildContext context) {
     super.build(context);
     return AnimatedOpacity(
-        opacity: (_height > 0) ? 1.0 : 0.0,
+        opacity: (_height > 1) ? 1.0 : 0.0,
         duration: Duration(seconds: 1),
         child: Padding(
           padding: EdgeInsets.fromLTRB(_left, _top, _right, _bottom),

--- a/lib/src/rokt_widget.dart
+++ b/lib/src/rokt_widget.dart
@@ -66,13 +66,16 @@ class _RoktContainerState extends State<RoktWidget>
   @override
   Widget build(BuildContext context) {
     super.build(context);
-    return Padding(
-      padding: EdgeInsets.fromLTRB(_left, _top, _right, _bottom),
-      child: SizedBox(
-          height: _height,
-          child: _RoktStatelessWidget(
-              platformViewCreatedCallback: _onPlatformViewCreated)),
-    );
+    return AnimatedOpacity(
+        opacity: (_height > 0) ? 1.0 : 0.0,
+        duration: Duration(seconds: 1),
+        child: Padding(
+          padding: EdgeInsets.fromLTRB(_left, _top, _right, _bottom),
+          child: SizedBox(
+              height: _height,
+              child: _RoktStatelessWidget(
+                  platformViewCreatedCallback: _onPlatformViewCreated)),
+        ));
   }
 
   void _onPlatformViewCreated(int id) {


### PR DESCRIPTION
### Background ###

This PR is to attempt to address flickering on the Flutter rokt widget view when it is being redrawn on setState()

Fixes https://rokt.atlassian.net/browse/MP-3389

### What Has Changed: ###

Wrap Rokt Widget in animated opacity view. Animated opacity view transitions to visible after height resize is applied.

### How Has This Been Tested? ###

Tested locally

### Checklist: ###

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have verified that CI completes successfully.
- [x] All insignificant commits have been squashed.