### PR TITLE
[CI-91] Rokt Config Wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ build/
 .project
 .classpath
 .settings
+
+.fvm/

--- a/lib/rokt_sdk.dart
+++ b/lib/rokt_sdk.dart
@@ -125,17 +125,17 @@ class RoktSdk {
 class RoktConfig {
   /// The device color mode your application is using
   /// Defaults to respecting the system's color mode
-  ColorMode? colorMode = ColorMode.SYSTEM;
+  ColorMode? colorMode = ColorMode.system;
 }
 
 /// Enum representing device color modes
 enum ColorMode {
   /// Request Light mode configuration
-  LIGHT,
+  light,
 
   /// Request Dark mode configuration
-  DARK,
+  dark,
 
   /// Request System's current configuration
-  SYSTEM
+  system
 }

--- a/lib/rokt_sdk.dart
+++ b/lib/rokt_sdk.dart
@@ -122,14 +122,16 @@ class RoktSdk {
 ///
 /// - Attributes
 ///   - [ColorMode]? colorMode: preferred device color mode configuration
-///
-/// Create the object using cascade notation e.g. <br>
-/// var config = RoktConfig() <br>
-/// &nbsp;&nbsp;..colorMode = ColorMode.light
+@immutable
 class RoktConfig {
   /// The device color mode your application is using
-  /// Defaults to respecting the system's color mode
-  ColorMode? colorMode = ColorMode.system;
+  final ColorMode colorMode;
+
+  /// Constructor
+  ///
+  /// - Parameters
+  ///   - [ColorMode]? colorMode: preferred device color mode configuration
+  const RoktConfig({this.colorMode = ColorMode.system});
 }
 
 /// Enum representing device color modes

--- a/lib/rokt_sdk.dart
+++ b/lib/rokt_sdk.dart
@@ -92,6 +92,7 @@ class RoktSdk {
   static Future<void> execute(
       {required String viewName,
       Map<String, String> attributes = const {},
+      RoktConfig? roktConfig,
       RoktCallback onLoad = _defaultRoktCallBack,
       RoktCallback onUnLoad = _defaultRoktCallBack,
       RoktCallback onShouldShowLoadingIndicator = _defaultRoktCallBack,
@@ -104,6 +105,7 @@ class RoktSdk {
     await RoktSdkController.instance.execute(
         viewName: viewName,
         attributes: attributes,
+        config: roktConfig,
         callback: _defaultRoktCallBackInternal);
   }
 
@@ -113,4 +115,27 @@ class RoktSdk {
   static Future<void> setLoggingEnabled({required bool enable}) async {
     await RoktSdkController.instance.setLoggingEnabled(enable: enable);
   }
+}
+
+/// Configuration settings for the Rokt SDK <br>
+///
+/// Create the object using cascade notation e.g.: <br>
+/// var config = RoktConfig() <br>
+/// &nbsp;&nbsp;..colorMode = ColorMode.LIGHT
+class RoktConfig {
+  /// The device color mode your application is using
+  /// Defaults to respecting the system's color mode
+  ColorMode? colorMode = ColorMode.SYSTEM;
+}
+
+/// Enum representing device color modes
+enum ColorMode {
+  /// Request Light mode configuration
+  LIGHT,
+
+  /// Request Dark mode configuration
+  DARK,
+
+  /// Request System's current configuration
+  SYSTEM
 }

--- a/lib/rokt_sdk.dart
+++ b/lib/rokt_sdk.dart
@@ -85,6 +85,7 @@ class RoktSdk {
   /// - Parameters:
   ///   - viewName: The name that should be displayed in the widget
   ///   - attributes: A string map containing the parameters that should be displayed in the widget
+  ///   - roktConfig: Rokt SDK configuration object
   ///   - onLoad: Function to execute right after the widget is successfully loaded and displayed
   ///   - onUnLoad: Function to execute right after widget is unloaded, there is no widget or there is an exception
   ///   - onShouldShowLoadingIndicator: Function to execute when the loading indicator should be shown
@@ -119,9 +120,12 @@ class RoktSdk {
 
 /// Configuration settings for the Rokt SDK <br>
 ///
-/// Create the object using cascade notation e.g.: <br>
+/// - Attributes
+///   - [ColorMode]? colorMode: preferred device color mode configuration
+///
+/// Create the object using cascade notation e.g. <br>
 /// var config = RoktConfig() <br>
-/// &nbsp;&nbsp;..colorMode = ColorMode.LIGHT
+/// &nbsp;&nbsp;..colorMode = ColorMode.light
 class RoktConfig {
   /// The device color mode your application is using
   /// Defaults to respecting the system's color mode

--- a/lib/src/rokt_sdk_controller.dart
+++ b/lib/src/rokt_sdk_controller.dart
@@ -79,7 +79,7 @@ class RoktSdkController {
 
   Map<String, dynamic> _roktConfigToMap({required RoktConfig? config}) {
     return {
-      'colorMode': config?.colorMode?.name ?? ColorMode.system.name,
+      'colorMode': config?.colorMode.name ?? ColorMode.system.name,
     };
   }
 }

--- a/lib/src/rokt_sdk_controller.dart
+++ b/lib/src/rokt_sdk_controller.dart
@@ -79,7 +79,7 @@ class RoktSdkController {
 
   Map<String, dynamic> _roktConfigToMap({required RoktConfig? config}) {
     return {
-      'colorMode': config?.colorMode?.name ?? ColorMode.SYSTEM.name,
+      'colorMode': config?.colorMode?.name ?? ColorMode.system.name,
     };
   }
 }

--- a/lib/src/rokt_sdk_controller.dart
+++ b/lib/src/rokt_sdk_controller.dart
@@ -79,7 +79,7 @@ class RoktSdkController {
 
   Map<String, dynamic> _roktConfigToMap({required RoktConfig? config}) {
     return {
-      'colorMode': config?.colorMode?.name ?? ColorMode.SYSTEM,
+      'colorMode': config?.colorMode?.name ?? ColorMode.SYSTEM.name,
     };
   }
 }

--- a/lib/src/rokt_sdk_controller.dart
+++ b/lib/src/rokt_sdk_controller.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
+import 'package:rokt_sdk/rokt_sdk.dart';
 
 /// Internal callBack for Rokt Sdk
 typedef RoktCallbackInternal = void Function(dynamic msg);
@@ -39,7 +40,8 @@ class RoktSdkController {
   Future<void> execute(
       {required String viewName,
       required Map<String, String> attributes,
-      required RoktCallbackInternal callback}) async {
+      required RoktCallbackInternal callback,
+      RoktConfig? config}) async {
     final int currentCallbackId = _nextCallbackId++;
     _callbacksById[currentCallbackId] = callback;
     await _channel.invokeMethod('execute', {
@@ -47,6 +49,7 @@ class RoktSdkController {
       'attributes': attributes,
       'placeholders': instance._placeholders,
       'callbackId': currentCallbackId,
+      'config': _roktConfigToMap(config: config),
     });
   }
 
@@ -72,5 +75,11 @@ class RoktSdkController {
           print('No method matching !!');
         }
     }
+  }
+
+  Map<String, dynamic> _roktConfigToMap({required RoktConfig? config}) {
+    return {
+      'colorMode': config?.colorMode?.name ?? ColorMode.SYSTEM,
+    };
   }
 }


### PR DESCRIPTION
### Background ###

Creating Dart interface for Rokt config. Builder pattern isn't really used in Dart since the same can be achieved by using named parameters with defaults instead of positionals. Any new attribute won't break backwards compatibility as long as it's optional or has a default. 

Fixes [CI-91](https://rokt.atlassian.net/browse/CI-91)

### What Has Changed: ###

- Added immutable RoktConfig class with named parameter colorMode

### How Has This Been Tested? ###

Tested with example app

### Notes

Will add native channel changes next

### Checklist: ###

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have verified that CI completes successfully.
- [ ] All insignificant commits have been squashed.