### PR TITLE
Support arm64 for iOS simulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ _ Run `flutter clean`
 - Delete /ios/Pods
 - Delete /ios/Podfile.lock 
 - Run `flutter pub get`
-- From inside ios folder, run `pod install` (or `arch -x86_64 pod install` for M1 Mac users)
+- From inside ios folder, run `pod install`
 
 ## Initializing the Rokt SDK
 Initialize the Rokt SDK prior to using it. We recommend calling the initialize method in the beginning of the applications.

--- a/ios/rokt_sdk.podspec
+++ b/ios/rokt_sdk.podspec
@@ -20,6 +20,6 @@ Rokt Mobile SDK to integrate ROKT Api into Flutter application.
   s.resource_bundles = { "Rokt-Widget" => ["PrivacyInfo.xcprivacy"] }
 
   # Flutter.framework does not contain a i386 slice.
-  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64'}
+  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }
   s.swift_version = '5.0'
 end


### PR DESCRIPTION
### Background ###

Currently, `rokt-sdk-flutter` excludes the arm64 simulator in the iOS podspec file.
However, `rokt-sdk-ios`, which `rokt-sdk-flutter` depends on, provides the SDK as a universal library including `x86_64` and `arm64`.

- https://github.com/ROKT/rokt-sdk-ios

```console
$ file ios-arm64_x86_64-simulator/Rokt_Widget.framework/Rokt_Widget
ios-arm64_x86_64-simulator/Rokt_Widget.framework/Rokt_Widget: Mach-O universal binary with 2 architectures: [x86_64:Mach-O 64-bit dynamically linked shared library x86_64] [arm64]
ios-arm64_x86_64-simulator/Rokt_Widget.framework/Rokt_Widget (for architecture x86_64): Mach-O 64-bit dynamically linked shared library x86_64
ios-arm64_x86_64-simulator/Rokt_Widget.framework/Rokt_Widget (for architecture arm64):  Mach-O 64-bit dynamically linked shared library arm64
```

I have checked the `arm64` build for `rokt-sdk-flutter`, and it works correctly with my Flutter app.

Running the simulator in a Rosetta (`x86_64`) environment on an M1 Mac causes the same problem as described below.
To work around this, you need to build for the `arm64` simulator.

- https://github.com/flutter/flutter/issues/93177

I would like to see `rokt-sdk-flutter` officially support the `arm64` simulator if possible.

### What Has Changed: ###

- Removed `'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64'` from `ios/rokt_sdk.podspec`
- Removed a special instruction for M1 Mac from `README.md`

### How Has This Been Tested? ###

- Successfully built the app on an M1 Mac and an Intel Mac
- Successfully ran the app on an iOS simulator on an M1 Mac and an Intel Mac

### Notes

None.

### Checklist: ###

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
  - -> Because there are no tests for the building process
- [ ] New and existing unit tests pass locally with my changes.
  - -> Because there are no tests for the building process
- [ ] I have verified that CI completes successfully.
  - -> Because CI verification is not working now
- [x] All insignificant commits have been squashed.
