### PR TITLE
LAYOUT-1331 - Implement init event in Android and iOS wrapper

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -51,6 +51,6 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation "com.rokt:roktsdk:4.4.0-alpha1"
+    implementation "com.rokt:roktsdk:4.5.2-alpha.2"
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.6.1"
 }

--- a/ios/rokt_sdk.podspec
+++ b/ios/rokt_sdk.podspec
@@ -15,7 +15,7 @@ Rokt Mobile SDK to integrate ROKT Api into Flutter application.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Rokt-Widget', '~> 4.4.0-alpha.1'
+  s.dependency 'Rokt-Widget', '~> 4.5.2-alpha.3'
   s.platform = :ios, '10.0'
   s.resource_bundles = { "Rokt-Widget" => ["PrivacyInfo.xcprivacy"] }
 


### PR DESCRIPTION
### Background ###

Refactor event subscription to reuse the handling.
Subscribe to the global events and propagate it to event listeners.

Fixes [LAYOUT-1331](https://rokt.atlassian.net/browse/LAYOUT-1331)

### What Has Changed: ###

Init complete event

### How Has This Been Tested? ###

Tested locally

iOS

https://github.com/user-attachments/assets/2b29b96c-41c9-4522-825f-c76676bd4899

Android

https://github.com/user-attachments/assets/dea4e471-ec23-4aa7-9828-7ae8823891a0


### Checklist: ###

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have verified that CI completes successfully.
- [x] All insignificant commits have been squashed.