### PR TITLE
NoJira - Fix the version conflict issue

### DIFF
--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -75,6 +75,16 @@ flutter {
     source '../..'
 }
 
+configurations.all {
+    resolutionStrategy {
+        eachDependency {
+            if (requested.group == "androidx.lifecycle" && requested.name == "lifecycle-livedata-core") {
+                useVersion("2.5.1")
+            }
+        }
+    }
+}
+
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.appcompat:appcompat:1.4.1'


### PR DESCRIPTION

### Background ###

Since the Example app is using an old AGP plugin it is failing in D8 step for lifecycle-livedata-core.
Force the app to use 2.5.1


### What Has Changed: ###

List out what has changed as a result of this PR.

### How Has This Been Tested? ###

Describe the tests that you ran to verify your changes. 

### Notes

Add any notes or extra information here that might be useful to the reviewer if applicable i.e. links to documentation/blogs or dashboards.

### Checklist: ###

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have verified that CI completes successfully.
- [x] All insignificant commits have been squashed.