### PR TITLE
NI-436 - fix button not clickable

### DIFF
--- a/example/ios/Flutter/AppFrameworkInfo.plist
+++ b/example/ios/Flutter/AppFrameworkInfo.plist
@@ -21,6 +21,6 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>9.0</string>
+  <string>12.0</string>
 </dict>
 </plist>

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 51;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -155,7 +155,7 @@
 		97C146E61CF9000F007C117D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1300;
+				LastUpgradeCheck = 1510;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {
@@ -199,10 +199,12 @@
 /* Begin PBXShellScriptBuildPhase section */
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
+				"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}",
 			);
 			name = "Thin Binary";
 			outputPaths = (
@@ -235,6 +237,7 @@
 		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -339,7 +342,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;
@@ -418,7 +421,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -467,7 +470,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;

--- a/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1510"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/example/ios/Runner/AppDelegate.swift
+++ b/example/ios/Runner/AppDelegate.swift
@@ -1,7 +1,7 @@
 import UIKit
 import Flutter
 
-@UIApplicationMain
+@main
 @objc class AppDelegate: FlutterAppDelegate {
   override func application(
     _ application: UIApplication,

--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -45,5 +45,7 @@
 	<false/>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
 </dict>
 </plist>

--- a/ios/Classes/FLRoktWidgetView.swift
+++ b/ios/Classes/FLRoktWidgetView.swift
@@ -19,6 +19,7 @@ class FLRoktWidgetView: NSObject, FlutterPlatformView {
     let roktEmbeddedView: RoktEmbeddedView
     let id: Int64
     let channel: FlutterMethodChannel
+    var constraints: [NSLayoutConstraint]?
     init(
         frame: CGRect,
         viewIdentifier viewId: Int64,
@@ -30,21 +31,28 @@ class FLRoktWidgetView: NSObject, FlutterPlatformView {
         roktEmbeddedView = RoktEmbeddedView()
         super.init()
     }
-    
+
     func view() -> UIView {
         return roktEmbeddedView
+    }
 
+    private func setupConstraintsIfNeeded() {
+        roktEmbeddedView.translatesAutoresizingMaskIntoConstraints = false
+        guard constraints == nil, let superview = roktEmbeddedView.superview else { return }
+        constraints = [
+            roktEmbeddedView.topAnchor.constraint(equalTo: superview.topAnchor),
+            roktEmbeddedView.trailingAnchor.constraint(equalTo: superview.trailingAnchor),
+            roktEmbeddedView.bottomAnchor.constraint(equalTo: superview.bottomAnchor),
+            roktEmbeddedView.leadingAnchor.constraint(equalTo: superview.leadingAnchor)
+        ]
+        constraints?.forEach{ $0.isActive = true }
+        superview.setNeedsLayout()
     }
-    
-    private func resizeFrame(_ newHeight: Double = 0) {
-        roktEmbeddedView.frame = CGRect(x: 0, y: 0, width: roktEmbeddedView.frame.width, height: newHeight)
-    }
-    
+
     func sendUpdatedHeight(height: Double){
         var callbackMap = [String: Any] ()
-        resizeFrame(height)
+        setupConstraintsIfNeeded()
         callbackMap["size"] = height
         channel.invokeMethod("viewHeightListener", arguments: callbackMap)
     }
 }
-

--- a/ios/rokt_sdk.podspec
+++ b/ios/rokt_sdk.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'rokt_sdk'
-  s.version          = '4.7.0-alpha.1'
+  s.version          = '4.7.0'
   s.summary          = 'Rokt Mobile SDK to integrate ROKT Api into Flutter application'
   s.description      = <<-DESC
 Rokt Mobile SDK to integrate ROKT Api into Flutter application.
@@ -15,7 +15,7 @@ Rokt Mobile SDK to integrate ROKT Api into Flutter application.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Rokt-Widget', '4.7.0-alpha.3'
+  s.dependency 'Rokt-Widget', '4.7.0'
   s.platform = :ios, '12.0'
   s.resource_bundles = { "Rokt-Widget" => ["PrivacyInfo.xcprivacy"] }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: rokt_sdk
 description: Rokt Mobile SDK to integrate ROKT Api into flutter applications.
-version: 4.7.0-alpha.1
+version: 4.7.0
 homepage: https://github.com/ROKT/rokt-sdk-flutter
 repository: https://github.com/ROKT/rokt-sdk-flutter
 


### PR DESCRIPTION
### Background ###

Flutter and iOS each have their own layout passes and timing and doesn't seem to be in sync. Eg. when we tap on a button, and the native view has finished laying out its views, the flutter container could still be using autoresizing masks for the previous dimensions resulting in breaking constraints. This affect is more obvious when the native view relies on the frame to be updated and has `translatesAutoresizingMasksEnabled == true`. Hence moving to layout constraints allowing the native view and flutter container to be self-sizing seems to help with this issue.

| | before | after |
|:-----:|:------:|:------:|
| native view with old autoresizing mask that breaks the height of the native view | <img width=500 src="https://github.com/user-attachments/assets/f9b919f9-e084-482f-b6a3-aaffbf528ebc" /> | <img width="500" alt="Screenshot 2025-01-16 at 9 40 02 AM" src="https://github.com/user-attachments/assets/b8b8b7c4-1d0c-42f6-b576-57bc4fa5186a" /> |


Fixes [([issue](https://rokt.atlassian.net/browse/NI-436))]


### What Has Changed: ###


List out what has changed as a result of this PR.

### How Has This Been Tested? ###

Describe the tests that you ran to verify your changes. 

### Notes

Add any notes or extra information here that might be useful to the reviewer if applicable i.e. links to documentation/blogs or dashboards.

### Checklist: ###

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have verified that CI completes successfully.
- [x] All insignificant commits have been squashed.