### PR TITLE
fix: update activesupport gem to resolve security vulnerabilities

### DIFF
--- a/example/Gemfile.lock
+++ b/example/Gemfile.lock
@@ -5,7 +5,7 @@ GEM
       base64
       nkf
       rexml
-    activesupport (7.2.2.1)
+    activesupport (7.2.3.1)
       base64
       benchmark (>= 0.3)
       bigdecimal

--- a/example/Gemfile.lock
+++ b/example/Gemfile.lock
@@ -14,7 +14,7 @@ GEM
       drb
       i18n (>= 1.6, < 2)
       logger (>= 1.4.2)
-      minitest (>= 5.1)
+      minitest (>= 5.1, < 6)
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
     addressable (2.8.7)

--- a/example/ios/Gemfile.lock
+++ b/example/ios/Gemfile.lock
@@ -5,7 +5,7 @@ GEM
       base64
       nkf
       rexml
-    activesupport (7.2.2.1)
+    activesupport (7.2.3.1)
       base64
       benchmark (>= 0.3)
       bigdecimal

--- a/example/ios/Gemfile.lock
+++ b/example/ios/Gemfile.lock
@@ -14,7 +14,7 @@ GEM
       drb
       i18n (>= 1.6, < 2)
       logger (>= 1.4.2)
-      minitest (>= 5.1)
+      minitest (>= 5.1, < 6)
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
     addressable (2.8.7)


### PR DESCRIPTION
## Summary

- Upgrades \`activesupport\` from \`7.2.2.1\` → \`7.2.3.1\` in \`example/Gemfile.lock\` and \`example/ios/Gemfile.lock\`
- Fixes 6 known CVEs (DoS, XSS, ReDoS) in the transitive Ruby dependency pulled in via \`cocoapods-core 1.15.2\`
- \`7.2.3.1\` satisfies the existing constraint \`activesupport >= 5.0, < 8\` — no other gems change

This was the remaining CI failure from PR #162, caught by \`osv-scanner\` in the trunk-check job.

## Test plan

- [ ] \`trunk-check\` CI job (osv-scanner) passes — no more activesupport vulnerability flagged
- [ ] iOS build & test job completes successfully with updated Gemfile.lock
- [ ] Android build & test job unaffected (no Ruby dependency)

🤖 Generated with [Claude Code](https://claude.com/claude-code)