### PR TITLE
ci: fix template injection findings and add zizmor CI check

### DIFF
--- a/.github/workflows/draft-release-publish.yml
+++ b/.github/workflows/draft-release-publish.yml
@@ -39,16 +39,20 @@ jobs:
           current_version: ${{ steps.version-file.outputs.release-version }}
           level: ${{ github.event.inputs.bump-type || 'patch' }}
       - name: Save validated version to file
+        env:
+          NEW_VERSION: ${{ steps.bump-version.outputs.new_version }}
         run: |
-          echo "${{ steps.bump-version.outputs.new_version }}" > VERSION
+          printf '%s\n' "$NEW_VERSION" > VERSION
       - name: Update changelog
         uses: thomaseizinger/keep-a-changelog-new-release@f62c3c390716df5af712ba5d94f4f4a8efc1306d # v3.1.0
         with:
           tag: ${{ steps.bump-version.outputs.new_version }}
 
       - name: Update pubspec.yaml
+        env:
+          NEW_VERSION: ${{ steps.bump-version.outputs.new_version }}
         run: |
-          sed -i 's/version: .*/version: ${{ steps.bump-version.outputs.new_version }}/' pubspec.yaml
+          sed -i "s/version: .*/version: ${NEW_VERSION}/" pubspec.yaml
 
       - name: Setup Flutter
         uses: subosito/flutter-action@fd55f4c5af5b953cc57a2be44cb082c8f6635e8e #2.21.0

--- a/.github/workflows/draft-release-publish.yml
+++ b/.github/workflows/draft-release-publish.yml
@@ -52,7 +52,7 @@ jobs:
         env:
           NEW_VERSION: ${{ steps.bump-version.outputs.new_version }}
         run: |
-          sed -i "s/version: .*/version: ${NEW_VERSION}/" pubspec.yaml
+          sed -i "s|^version: .*|version: ${NEW_VERSION}|" pubspec.yaml
 
       - name: Setup Flutter
         uses: subosito/flutter-action@fd55f4c5af5b953cc57a2be44cb082c8f6635e8e #2.21.0

--- a/.github/workflows/release-from-main.yml
+++ b/.github/workflows/release-from-main.yml
@@ -80,7 +80,7 @@ jobs:
         with:
           changelog_file: CHANGELOG.md
           release_notes_file: ${{ needs.setup-and-version.outputs.final_version }}.md
-      - name: Changelog
+      - name: Print release notes (debug)
         env:
           RELEASE_NOTES: ${{ steps.extract-release-notes.outputs.release_notes }}
         run: printf '%s\n' "$RELEASE_NOTES"

--- a/.github/workflows/release-from-main.yml
+++ b/.github/workflows/release-from-main.yml
@@ -81,7 +81,9 @@ jobs:
           changelog_file: CHANGELOG.md
           release_notes_file: ${{ needs.setup-and-version.outputs.final_version }}.md
       - name: Changelog
-        run: echo "${{ steps.extract-release-notes.outputs.release_notes }}"
+        env:
+          RELEASE_NOTES: ${{ steps.extract-release-notes.outputs.release_notes }}
+        run: printf '%s\n' "$RELEASE_NOTES"
       - name: Upload release notes
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4.6.2
         with:
@@ -125,8 +127,10 @@ jobs:
           path: ${{ needs.setup-and-version.outputs.final_version }}.md
 
       - name: Move release notes to docs
+        env:
+          FINAL_VERSION: ${{ needs.setup-and-version.outputs.final_version }}
         run: |
-          mv ${{ needs.setup-and-version.outputs.final_version }}.md changelogs/flutter/${{ needs.setup-and-version.outputs.final_version }}.md
+          mv "${FINAL_VERSION}.md" "changelogs/flutter/${FINAL_VERSION}.md"
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -34,10 +34,13 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
-          fetch-depth: 1
+          fetch-depth: 1 # zizmor only needs the tree at HEAD
       - name: Run zizmor
         uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2
-        continue-on-error: true # Permanent — reports findings without blocking PRs
+        # Permanent advisory mode — zizmor is rolled out across Rokt repos as a
+        # reporter, not a gate. Findings surface as PR annotations so owners
+        # can triage incrementally without blocking unrelated changes.
+        continue-on-error: true
         with:
-          advanced-security: false
-          annotations: true
+          advanced-security: false # no SARIF upload (GHAS not enabled on private repo)
+          annotations: true # inline PR annotations (GitHub caps at 10/run)

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,43 @@
+name: Zizmor Security Scan
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/workflows/**
+      - .github/actions/**
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/**
+      - .github/actions/**
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions: {} # deny-by-default; job below grants only what it needs
+
+jobs:
+  zizmor:
+    name: Scan GitHub Actions workflows
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      actions: read # zizmor resolves reusable workflow/action metadata via GitHub API
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2
+        continue-on-error: true # Permanent — reports findings without blocking PRs
+        with:
+          advanced-security: false
+          annotations: true

--- a/example/Gemfile.lock
+++ b/example/Gemfile.lock
@@ -18,7 +18,7 @@ GEM
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
     addressable (2.9.0)
-      public_suffix (>= 2.0.2, < 7.0)
+      public_suffix (< 8.0, >= 2.0.2)
     algoliasearch (1.27.5)
       httpclient (~> 2.8, >= 2.8.3)
       json (>= 1.5.1)

--- a/example/Gemfile.lock
+++ b/example/Gemfile.lock
@@ -17,7 +17,7 @@ GEM
       minitest (>= 5.1, < 6)
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
-    addressable (2.8.7)
+    addressable (2.9.0)
       public_suffix (>= 2.0.2, < 7.0)
     algoliasearch (1.27.5)
       httpclient (~> 2.8, >= 2.8.3)

--- a/example/ios/Gemfile.lock
+++ b/example/ios/Gemfile.lock
@@ -18,7 +18,7 @@ GEM
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
     addressable (2.9.0)
-      public_suffix (>= 2.0.2, < 7.0)
+      public_suffix (< 8.0, >= 2.0.2)
     algoliasearch (1.27.5)
       httpclient (~> 2.8, >= 2.8.3)
       json (>= 1.5.1)

--- a/example/ios/Gemfile.lock
+++ b/example/ios/Gemfile.lock
@@ -17,7 +17,7 @@ GEM
       minitest (>= 5.1, < 6)
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
-    addressable (2.8.7)
+    addressable (2.9.0)
       public_suffix (>= 2.0.2, < 7.0)
     algoliasearch (1.27.5)
       httpclient (~> 2.8, >= 2.8.3)


### PR DESCRIPTION
## Summary

Fixes **5 template-injection findings** flagged by [zizmor](https://zizmor.sh/) by moving `${{ }}` expressions in `run:` blocks to `env:` variables. Also adds a new `zizmor.yml` CI workflow that scans `.github/workflows/` and `.github/actions/` on every PR and push to `main`.

## Fixes

### Template injection

| Workflow | Line | Expression |
|----------|------|------------|
| `draft-release-publish.yml` | 43 | `steps.bump-version.outputs.new_version` (echo into VERSION) |
| `draft-release-publish.yml` | 51 | `steps.bump-version.outputs.new_version` (sed into pubspec.yaml) |
| `release-from-main.yml` | 84 | `steps.extract-release-notes.outputs.release_notes` |
| `release-from-main.yml` | 129 | `needs.setup-and-version.outputs.final_version` (2 instances in same line) |

Fix pattern: move the expression into a **step-level** `env:` block (narrowest scope — zizmor-recommended) and reference it as a shell variable (e.g. `"$NEW_VERSION"`), using `printf '%s'` instead of `echo` where output is needed. `NEW_VERSION` is intentionally declared in two separate step-level `env:` blocks rather than hoisted to job level to keep the blast radius minimal.

The `sed` step uses `|` as the delimiter and anchors with `^` so a future version string containing `/`, `&`, or other sed metacharacters cannot corrupt `pubspec.yaml`.

### New zizmor CI workflow

`.github/workflows/zizmor.yml` — runs on PRs and pushes touching `.github/workflows/**` or `.github/actions/**`, plus `workflow_dispatch` for manual historical scans.
- `continue-on-error: true` — **permanent advisory mode**. zizmor is rolled out across Rokt repos as a reporter, not a gate; findings surface as PR annotations so owners can triage incrementally without blocking unrelated changes.
- `annotations: true` — inline PR annotations (capped at 10 per run by GitHub)
- `advanced-security: false` — disables SARIF upload to GitHub code scanning (GHAS not enabled on private repo)
- `permissions: {}` at workflow level (deny-by-default); job grants `contents: read` + `actions: read` (needed for zizmor's API metadata resolution, not for annotations)
- Concurrency group cancels in-progress runs on rapid pushes
- `fetch-depth: 1` — zizmor only needs the tree at HEAD

## Out of scope

The following are **intentionally not fixed** in this PR and will surface as pre-existing zizmor annotations:

- **`${{ }}` expressions in `with:` blocks** (e.g. `release_notes_file: ${{ needs.setup-and-version.outputs.final_version }}.md` at release-from-main.yml:82 and `path: ${{ needs.setup-and-version.outputs.final_version }}.md` at line 127) — these are **not** template-injection targets. Template injection only applies to `run:` shell contexts.
- **`excessive-permissions`** at release-from-main.yml:15 (workflow-level `contents: write`) — scoped to a separate permissions-tightening PR.
- **6 × `secrets-outside-env`** findings on `SDK_RELEASE_GITHUB_APP_ID` / `SDK_RELEASE_GITHUB_APP_PRIVATE_KEY` — requires creating GitHub Environments for release secrets; scoped to a separate PR.

## Verification

```
cd /tmp/rokt-sdk-flutter
zizmor --persona=auditor .github/workflows/ 2>&1 | grep '\[template-injection\]' | wc -l
# 0
```

All 5 template-injection findings now clear.

## Fork PRs

This is a private repo; fork PRs do not apply.

## Test plan

- [ ] CI passes (zizmor workflow runs and reports findings inline)
- [ ] Template injection findings no longer reported by zizmor scan
- [ ] Release workflows (`draft-release-publish`, `release-from-main`) are functionally unchanged