### PR TITLE
fix: enable pub.dev publishing in GitHub Actions

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -40,6 +40,9 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1.7.2
+
       - name: Setup Flutter
         uses: subosito/flutter-action@fd55f4c5af5b953cc57a2be44cb082c8f6635e8e #2.21.0
         with:


### PR DESCRIPTION
## Background

- The release publish workflow currently falls back to interactive browser authorization instead of using GitHub Actions OIDC, which blocks tagged pub.dev releases.
- This change updates the workflow so package publishing can authenticate non-interactively in CI.

## What Has Changed

- Added `dart-lang/setup-dart` before Flutter setup in the release publish workflow.
- Kept the existing Flutter-based publish step, but enabled it to use the GitHub Actions OIDC token path expected by pub.dev.
- Left the rest of the release workflow unchanged.

## Screenshots/Video

- N/A — no visual changes.

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have tested this locally.

## Additional Notes

- Before rerunning the release, uncheck the required GitHub Actions environment setting in the pub.dev admin console.
- Local validation: `trunk check --ci` passed and `flutter test` passed in `example/`.
- The root `flutter test` suite currently has existing unrelated failures in `test/rokt_sdk_test.dart` around `selectShoppableAds` and `registerPaymentExtension`.