### PR TITLE
ci: rename release-and-tag job to publish-and-release

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -28,7 +28,7 @@ jobs:
     with:
       flutter-version: ${{ vars.FLUTTER_VERSION }}
 
-  release-and-tag:
+  publish-and-release:
     needs: [build-test-ios, build-test-android]
     runs-on: ubuntu-latest
     permissions:
@@ -78,7 +78,7 @@ jobs:
             ${{ steps.extract-release-notes.outputs.release_notes }}
 
   upload-release-notes:
-    needs: [release-and-tag]
+    needs: [publish-and-release]
     runs-on: ubuntu-latest
     steps:
       - name: Generate a token


### PR DESCRIPTION
## Background

- The `release-and-tag` job name in `release-publish.yml` was misleading — the job publishes to pub.dev and creates a GitHub release, but doesn't create the tag (the tag already exists when this workflow triggers).

## What Has Changed

- Renamed job `release-and-tag` → `publish-and-release` in `.github/workflows/release-publish.yml`
- Updated the `needs` reference in `upload-release-notes` to match

## Checklist

- [ ] Self-review completed
- [ ] Tests added or updated
- [ ] Tested locally