### PR TITLE
feat: add CNAME support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# AGENTS
+
+## Versioning
+
+- Never edit the `VERSION` file, `version:` in `pubspec.yaml`, or `s.version` in `ios/rokt_sdk.podspec`. The Flutter plugin version is bumped by the release workflow, not in feature PRs.
+- Native SDK dependency versions (`Rokt-Widget` in the podspec, `com.rokt:roktsdk` in `android/build.gradle`) can be bumped as part of feature work that requires them.
+- Add user-visible changes to the `## [Unreleased]` section of `CHANGELOG.md`. Do not add a new dated version heading — the release workflow does that.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `RoktSdk.setCustomBaseURL()` API to route SDK traffic through a custom CNAME domain. Must be called before `initialize()`. HTTPS-only; path/query/fragment are stripped, port is preserved.
+
+### Changed
+
+- Update Rokt native SDK versions: iOS 5.2.1, Android 5.1.0
+
 ## [5.0.0] - 2026-04-23
 
 ### Added

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -60,6 +60,6 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation "com.rokt:roktsdk:5.0.0"
+    implementation "com.rokt:roktsdk:5.1.0"
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.6.1"
 }

--- a/android/src/main/kotlin/com/rokt/rokt_sdk/MethodCallHandlerImpl.kt
+++ b/android/src/main/kotlin/com/rokt/rokt_sdk/MethodCallHandlerImpl.kt
@@ -19,6 +19,8 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
 import java.lang.ref.WeakReference
+import java.net.MalformedURLException
+import java.net.URL
 
 class MethodCallHandlerImpl(
     private val messenger: BinaryMessenger,
@@ -41,6 +43,10 @@ class MethodCallHandlerImpl(
         when (call.method) {
             INIT_METHOD -> {
                 init(call, result)
+            }
+
+            SET_CUSTOM_BASE_URL_METHOD -> {
+                setCustomBaseURL(call, result)
             }
 
             SELECT_PLACEMENTS_METHOD -> {
@@ -121,6 +127,31 @@ class MethodCallHandlerImpl(
 
     private fun getSessionId(result: MethodChannel.Result) {
         result.success(Rokt.getSessionId())
+    }
+
+    private fun setCustomBaseURL(
+        call: MethodCall,
+        result: MethodChannel.Result,
+    ) {
+        val urlString = call.argument<String>("url")
+        if (urlString.isNullOrEmpty()) {
+            result.error(
+                "INVALID_PARAMS",
+                "url is required",
+                null,
+            )
+            return
+        }
+        try {
+            Rokt.setCustomBaseURL(URL(urlString))
+            result.success("Success")
+        } catch (e: MalformedURLException) {
+            result.error(
+                "INVALID_URL",
+                "Malformed URL: ${e.message}",
+                null,
+            )
+        }
     }
 
     private fun init(
@@ -319,6 +350,7 @@ class MethodCallHandlerImpl(
     companion object {
         private const val CHANNEL_NAME = "rokt_sdk"
         private const val INIT_METHOD = "initialize"
+        private const val SET_CUSTOM_BASE_URL_METHOD = "setCustomBaseURL"
         private const val SELECT_PLACEMENTS_METHOD = "selectPlacements"
         private const val PURCHASE_FINALIZED_METHOD = "purchaseFinalized"
         private const val SET_SESSION_ID_METHOD = "setSessionId"

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -33,7 +33,7 @@ target 'Runner' do
 
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
 
-  pod 'RoktStripePaymentExtension', :git => 'https://github.com/ROKT/rokt-payment-extension-ios.git', :tag => '0.1.2'
+  pod 'RoktPaymentExtension', :git => 'https://github.com/ROKT/rokt-payment-extension-ios.git', :tag => '2.0.3'
 end
 
 post_install do |installer|

--- a/example/ios/Runner/AppDelegate.swift
+++ b/example/ios/Runner/AppDelegate.swift
@@ -1,7 +1,7 @@
 import UIKit
 import Flutter
 import rokt_sdk
-import RoktStripePaymentExtension
+import RoktPaymentExtension
 
 @main
 @objc class AppDelegate: FlutterAppDelegate {
@@ -14,7 +14,7 @@ import RoktStripePaymentExtension
     SwiftRoktSdkPlugin.paymentExtensionFactory = { type, config in
       switch type {
       case "stripe":
-        return RoktStripePaymentExtension(
+        return RoktPaymentExtension(
           applePayMerchantId: "merchant.com.runner.rokt"
         )
       default:

--- a/example/lib/assets/constants.dart
+++ b/example/lib/assets/constants.dart
@@ -1,5 +1,9 @@
 const String defaultTagId = "2754655826098840951";
 const String defaultViewName = "MSDKEmbeddedLayout";
+// Replace with a partner CNAME (e.g. https://rkt.partner.com) to route SDK
+// traffic through a first-party domain. Default points at the standard Rokt
+// host so the example works without any CNAME configured.
+const String defaultCustomBaseUrl = "https://apps.rokt.com";
 
 const String androidAttributes = """{
   "email": "j.smith@example.com",

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -27,6 +27,8 @@ class _MyAppState extends State<MyApp> {
           ? constants.iOSAttributes
           : constants.androidAttributes);
   final stripeKeyController = TextEditingController(text: "");
+  final customBaseUrlController =
+      TextEditingController(text: constants.defaultCustomBaseUrl);
   Map<int, String> placeholders = {};
   static const EventChannel roktEventChannel = EventChannel('RoktEvents');
 
@@ -72,6 +74,25 @@ class _MyAppState extends State<MyApp> {
                   sliver: SliverList(
                     delegate: SliverChildListDelegate(
                       <Widget>[
+                        Row(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Expanded(
+                                  child: TextField(
+                                      controller: customBaseUrlController,
+                                      textAlign: TextAlign.center,
+                                      decoration: const InputDecoration(
+                                          hintText: "Custom Base URL"))),
+                              TextButton(
+                                child: const Text('Set CNAME'),
+                                onPressed: () {
+                                  RoktSdk.setCustomBaseURL(
+                                      customBaseUrlController.text);
+                                  debugPrint(
+                                      "rokt_sdk custom base URL set to ${customBaseUrlController.text}");
+                                },
+                              )
+                            ]),
                         Row(
                             crossAxisAlignment: CrossAxisAlignment.start,
                             children: [

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -57,12 +57,52 @@ class _MyAppState extends State<MyApp> {
     return Map<String, String>.from(json.decode(attributesController.text));
   }
 
+  Future<void> _showCustomBaseUrlDialog(BuildContext context) async {
+    await showDialog<void>(
+      context: context,
+      builder: (BuildContext dialogContext) {
+        return AlertDialog(
+          title: const Text('Set Custom Base URL'),
+          content: TextField(
+            controller: customBaseUrlController,
+            decoration:
+                const InputDecoration(hintText: "https://rkt.partner.com"),
+          ),
+          actions: <Widget>[
+            TextButton(
+              child: const Text('Cancel'),
+              onPressed: () => Navigator.of(dialogContext).pop(),
+            ),
+            TextButton(
+              child: const Text('Set'),
+              onPressed: () {
+                RoktSdk.setCustomBaseURL(customBaseUrlController.text);
+                debugPrint(
+                    "rokt_sdk custom base URL set to ${customBaseUrlController.text}");
+                Navigator.of(dialogContext).pop();
+              },
+            ),
+          ],
+        );
+      },
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
         home: Scaffold(
             appBar: AppBar(
               title: const Text('Plugin example app'),
+              actions: <Widget>[
+                Builder(
+                  builder: (BuildContext appBarContext) => IconButton(
+                    icon: const Icon(Icons.dns_outlined),
+                    tooltip: 'Set Custom Base URL (CNAME)',
+                    onPressed: () => _showCustomBaseUrlDialog(appBarContext),
+                  ),
+                ),
+              ],
             ),
             body: GestureDetector(
               onTap: () {
@@ -74,25 +114,6 @@ class _MyAppState extends State<MyApp> {
                   sliver: SliverList(
                     delegate: SliverChildListDelegate(
                       <Widget>[
-                        Row(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              Expanded(
-                                  child: TextField(
-                                      controller: customBaseUrlController,
-                                      textAlign: TextAlign.center,
-                                      decoration: const InputDecoration(
-                                          hintText: "Custom Base URL"))),
-                              TextButton(
-                                child: const Text('Set CNAME'),
-                                onPressed: () {
-                                  RoktSdk.setCustomBaseURL(
-                                      customBaseUrlController.text);
-                                  debugPrint(
-                                      "rokt_sdk custom base URL set to ${customBaseUrlController.text}");
-                                },
-                              )
-                            ]),
                         Row(
                             crossAxisAlignment: CrossAxisAlignment.start,
                             children: [

--- a/ios/Classes/RoktMethodCallHandler.swift
+++ b/ios/Classes/RoktMethodCallHandler.swift
@@ -44,6 +44,18 @@ class RoktMethodCallHandler: NSObject, FlutterStreamHandler {
         return nil
     }
 
+    public func setCustomBaseURL(_ call: FlutterMethodCall,
+                                 result: @escaping FlutterResult) {
+        if let args = call.arguments as? Dictionary<String, Any>,
+           let urlString = args["url"] as? String,
+           let url = URL(string: urlString) {
+            Rokt.setCustomBaseURL(url)
+            result(SUCCESS)
+        } else {
+            result(FAIL)
+        }
+    }
+
     public func initialize(_ call: FlutterMethodCall,
                            result: @escaping FlutterResult) {
 

--- a/ios/Classes/SwiftRoktSdkPlugin.swift
+++ b/ios/Classes/SwiftRoktSdkPlugin.swift
@@ -22,6 +22,7 @@ public class SwiftRoktSdkPlugin: NSObject, FlutterPlugin {
     public static var paymentExtensionFactory: ((_ type: String, _ config: [String: String]) -> PaymentExtension?)?
 
     fileprivate let INIT_METHOD = "initialize"
+    fileprivate let SET_CUSTOM_BASE_URL_METHOD = "setCustomBaseURL"
     fileprivate let SELECT_PLACEMENTS_METHOD = "selectPlacements"
     fileprivate let SELECT_SHOPPABLE_ADS_METHOD = "selectShoppableAds"
     fileprivate let REGISTER_PAYMENT_EXTENSION_METHOD = "registerPaymentExtension"
@@ -55,6 +56,8 @@ public class SwiftRoktSdkPlugin: NSObject, FlutterPlugin {
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         if call.method == INIT_METHOD {
             handler.initialize(call, result: result)
+        } else if call.method == SET_CUSTOM_BASE_URL_METHOD {
+            handler.setCustomBaseURL(call, result: result)
         } else if call.method == SELECT_PLACEMENTS_METHOD {
             handler.selectPlacements(call, result: result)
         } else if call.method == SELECT_SHOPPABLE_ADS_METHOD {

--- a/ios/rokt_sdk.podspec
+++ b/ios/rokt_sdk.podspec
@@ -15,7 +15,7 @@ Rokt Mobile SDK to integrate ROKT Api into Flutter application.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Rokt-Widget', '~> 5.0'
+  s.dependency 'Rokt-Widget', '~> 5.2.1'
   s.platform = :ios, '15.0'
   s.resource_bundles = { "Rokt-Widget" => ["PrivacyInfo.xcprivacy"] }
 

--- a/lib/rokt_sdk.dart
+++ b/lib/rokt_sdk.dart
@@ -34,6 +34,19 @@ class RoktSdk {
         fontFilePathMap: fontFilePathMap);
   }
 
+  /// Routes all Rokt SDK requests through a custom CNAME domain.
+  ///
+  /// Must be called before [initialize]. Non-HTTPS URLs or URLs with a
+  /// missing/empty host are rejected by the native SDK with a warning. Any
+  /// path, query, or fragment on the URL is ignored — only the scheme, host,
+  /// and port are used.
+  ///
+  /// - Parameters:
+  ///   - url: The custom HTTPS base URL (e.g. `https://rkt.example.com`).
+  static Future<void> setCustomBaseURL(String url) async {
+    await RoktSdkController.instance.setCustomBaseURL(url: url);
+  }
+
   /// Select Rokt placements
   ///
   /// This is the entry point to select and display placements for a given view.

--- a/lib/src/rokt_sdk_controller.dart
+++ b/lib/src/rokt_sdk_controller.dart
@@ -27,6 +27,11 @@ class RoktSdkController {
     });
   }
 
+  /// Call Rokt setCustomBaseURL method in Native SDK
+  Future<void> setCustomBaseURL({required String url}) async {
+    await _channel.invokeMethod('setCustomBaseURL', {'url': url});
+  }
+
   /// Call Rokt selectPlacements method in Native SDK
   Future<void> selectPlacements(
       {required String viewName,

--- a/test/rokt_sdk_test.dart
+++ b/test/rokt_sdk_test.dart
@@ -51,6 +51,16 @@ void main() {
     });
   });
 
+  group('setCustomBaseURL', () {
+    test('sends url to native', () async {
+      await RoktSdk.setCustomBaseURL('https://rkt.example.com');
+
+      expect(log, hasLength(1));
+      expect(log.first.method, 'setCustomBaseURL');
+      expect(log.first.arguments['url'], 'https://rkt.example.com');
+    });
+  });
+
   group('selectPlacements', () {
     test('sends correct arguments with defaults', () async {
       await RoktSdk.selectPlacements(viewName: 'TestView');


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Background

- Partners want to route Rokt SDK traffic through a first-party CNAME (e.g. `rkt.partner.com`) to reduce blocking by ad blockers and keep traffic on the partner's domain.
- Native support already landed in [rokt-sdk-ios#148](https://github.com/ROKT/rokt-sdk-ios/pull/148) (5.2.0/5.2.1) and [sdk-android-source#993](https://github.com/ROKT/sdk-android-source/pull/993) (5.1.0). This PR surfaces the API to Flutter consumers.

## What Has Changed

### Dependency bumps

- iOS `Rokt-Widget ~> 5.2.1`, Android `com.rokt:roktsdk 5.1.0`.
- Example app payment extension migrated from `RoktStripePaymentExtension 0.1.2` to `RoktPaymentExtension 2.0.3` (required for `Rokt-Widget 5.2.x`, which depends on `RoktContracts >= 2.0.1`).

### Dart API

- New `RoktSdk.setCustomBaseURL(String url)` on the public `RoktSdk` class. Must be called before `initialize()`. Forwards to native via the existing MethodChannel.

### iOS native bridge

- `RoktMethodCallHandler.setCustomBaseURL` reads the `url` arg, constructs a `URL`, and calls `Rokt.setCustomBaseURL(_:)`. Validation (HTTPS-only, valid host, path/query/fragment stripped, port preserved) lives in the native SDK.

### Android native bridge

- `MethodCallHandlerImpl.setCustomBaseURL` reads the `url` arg, constructs a `java.net.URL`, and calls `Rokt.setCustomBaseURL(URL)`. `MalformedURLException` is surfaced as an `INVALID_URL` MethodChannel error.

### Example app

- Added a "Custom Base URL" input row above the tag-id row with a `Set CNAME` button. Defaults to `https://apps.rokt.com` with a comment instructing testers to swap in a partner CNAME — keeps the example runnable out-of-the-box without a CNAME configured.
- AppDelegate updated for the renamed `RoktPaymentExtension` module/class.

### Tests

- Unit test verifies the Dart→MethodChannel call uses method name `setCustomBaseURL` and forwards the `url` arg. Native-side validation is covered by the iOS and Android SDK PRs.

### Repository docs

- Added `AGENTS.md` documenting that feature PRs must not bump the Flutter plugin version (`VERSION`, `pubspec.yaml`, `s.version` in the podspec) — release workflow owns that.

## Screenshots/Video

- Example app showing the new CNAME input row with partner site entered for manual testing against the CNAME.

<img width="1100" height="120" alt="Screenshot 2026-05-19 at 10 00 08 AM" src="https://github.com/user-attachments/assets/9e32f4d5-2c43-4695-87eb-2c6e8a587339" />

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Additional Notes

- Manually tested against partner site on the iOS simulator.

## Reference Issue (For employees only. Ignore if you are an outside contributor)

- Closes [ticket](https://go/j/[ticket-number])