### PR TITLE
feat: Update to Latest Rokt SDK

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -43,7 +43,7 @@ jobs:
     with:
       flutter-version: ${{ vars.FLUTTER_VERSION }}
       ruby-version: ${{ vars.RUBY_VERSION }}
-      xcode-version: "16.4"
+      xcode-version: "26.3"
 
   build-test-android:
     name: Build & Test Android

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -20,7 +20,7 @@ jobs:
     with:
       flutter-version: ${{ vars.FLUTTER_VERSION }}
       ruby-version: ${{ vars.RUBY_VERSION }}
-      xcode-version: "16.4"
+      xcode-version: "26.3"
 
   build-test-android:
     name: Build & Test Android

--- a/.github/workflows/test-ios.yml
+++ b/.github/workflows/test-ios.yml
@@ -14,7 +14,7 @@ on:
       xcode-version:
         required: false
         type: string
-        default: "16.4"
+        default: "26.3"
 
 permissions:
   contents: read
@@ -64,7 +64,9 @@ jobs:
       - uses: futureware-tech/simulator-action@dab10d813144ef59b48d401cd95da151222ef8cd #v4
         id: simulator
         with:
-          model: iPhone 16
+          model: iPhone 17 Pro
+          os_version: ">=26.0"
+          wait_for_boot: true
 
       - name: Run Flutter Tests (iOS)
         working-directory: example

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Update Rokt native SDK versions: iOS 5.2.1, Android 5.1.0
+- Update Rokt native SDK versions: iOS 5.3.0, Android 6.0.1
+- Raise Android `minSdkVersion` to 23 to match Rokt Android SDK 6.x requirements
 
 ## [5.0.0] - 2026-04-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update Rokt native SDK versions: iOS 5.3.0, Android 6.0.1
 - Raise Android `minSdkVersion` to 23 to match Rokt Android SDK 6.x requirements
+- Run iOS integration tests on an iPhone 17 Pro simulator with iOS 26+ and Xcode 26.3, where Rokt SDK initialization succeeds
 
 ## [5.0.0] - 2026-04-23
 

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ The Rokt Flutter SDK is structured as a Flutter plugin that provides a Dart inte
 
 - **Dart Interface Layer**: Located in the `lib` directory, provides the API surface for Flutter applications
 - **Platform-Specific Implementations**:
-  - `android` directory contains the Kotlin implementation using the native Android Rokt-Widget SDK
-  - `ios` directory contains the Swift implementation using the native iOS Rokt-Widget SDK
+  - `android` directory contains the Kotlin implementation using the native Android Rokt SDK (`com.rokt:roktsdk`)
+  - `ios` directory contains the Swift implementation using the native iOS Rokt SDK (`Rokt-Widget`)
 - **Example Application**: Located in the `example` directory, demonstrates how to implement the SDK
 
 The SDK follows a bridge pattern to connect the Flutter framework with native platform capabilities, enabling seamless integration with Rokt's services.
@@ -35,9 +35,10 @@ To develop with or contribute to this SDK, you'll need:
 - [Flutter SDK](https://docs.flutter.dev/get-started/install/macos) properly installed and configured
 - [Android Studio](https://developer.android.com/studio) or [VS Code](https://code.visualstudio.com/) with Flutter plugins
 - For Android development:
-  - Kotlin version 1.8.0 or newer
-  - Android Gradle plugin 7.4.0 or newer
-  - Gradle version 7.5 or newer
+  - Kotlin 2.1.20 or newer (required by Rokt Android SDK 6.x)
+  - Android Gradle Plugin 8.6.0 or newer
+  - Gradle 8.9 or newer
+  - Android API level 23+ (minSdk)
 - For iOS development:
   - iOS 15 or above
   - Xcode with required dependencies
@@ -72,19 +73,21 @@ dependencies:
   flutter:
     sdk: flutter
 
-  rokt_sdk: ^4.0.0
+  rokt_sdk: ^5.0.0
 ```
 
 ### Platform-Specific Setup
 
 #### Android
 
+Requires Android API level 23+ (Android 6.0 Marshmallow or above).
+
 1. Set the minSdkVersion and enable multidex in `android/app/build.gradle`:
 
 ```gradle
 android {
   defaultConfig {
-    minSdkVersion 21
+    minSdkVersion 23
     multidexEnabled true
   }
 }
@@ -93,7 +96,7 @@ android {
 2. Include appcompat dependency:
 
    ```gradle
-   implementation 'androidx.appcompat:appcompat:x.x.x'
+   implementation 'androidx.appcompat:appcompat:1.4.1'
    ```
 
 3. The theme of android/app should extend from AppCompat Theme family:
@@ -159,13 +162,13 @@ Shoppable Ads allow users to make instant purchases directly from ad placements.
 1. Add the native payment extension to your iOS project (e.g. in your `Podfile`):
 
 ```ruby
-pod 'RoktStripePaymentExtension', '~> 0.1'
+pod 'RoktPaymentExtension', :git => 'https://github.com/ROKT/rokt-payment-extension-ios.git', :tag => '2.0.3'
 ```
 
 2. Set the payment extension factory in your `AppDelegate.swift`:
 
 ```swift
-import RoktStripePaymentExtension
+import RoktPaymentExtension
 import rokt_sdk
 
 // In application(_:didFinishLaunchingWithOptions:), after GeneratedPluginRegistrant.register:
@@ -173,9 +176,8 @@ SwiftRoktSdkPlugin.paymentExtensionFactory = { type, config in
     switch type {
     case "stripe":
         guard let merchantId = config["applePayMerchantId"] else { return nil }
-        return RoktStripePaymentExtension(
-            applePayMerchantId: merchantId,
-            countryCode: config["countryCode"] ?? "US"
+        return RoktPaymentExtension(
+            applePayMerchantId: merchantId
         )
     default:
         return nil
@@ -209,7 +211,7 @@ RoktSdk.selectShoppableAds(
 );
 ```
 
-3. Handle shoppable events via the `RoktEvents` EventChannel:
+4. Handle shoppable events via the `RoktEvents` EventChannel:
 
 ```dart
 const EventChannel roktEventChannel = EventChannel('RoktEvents');
@@ -226,42 +228,50 @@ roktEventChannel.receiveBroadcastStream().listen((dynamic event) {
 
 ## Key Dependencies & Gotchas
 
+### Native SDK Versions
+
+This Flutter plugin bundles the following native SDK versions:
+
+| Platform | Native dependency | Version |
+| -------- | ----------------- | ------- |
+| Android  | `com.rokt:roktsdk` | 6.0.1 |
+| iOS      | `Rokt-Widget` | 5.3.0 |
+
 ### Dependencies
 
 - **Android**:
   - Requires `androidx.appcompat` compatibility
-  - Uses native Android Rokt-Widget SDK (currently referenced version in `android/build.gradle`)
+  - Uses `com.rokt:roktsdk` from Maven Central (see `android/build.gradle`)
+  - Requires minSdk 23 and Kotlin 2.1.20+ when building the plugin locally
 
 - **iOS**:
-  - Uses native iOS Rokt-Widget SDK (referenced in `ios/rokt_sdk.podspec`)
+  - Uses `Rokt-Widget` from CocoaPods (see `ios/rokt_sdk.podspec`)
+  - Requires iOS 15.0+
 
 #### Updating Native SDKs
 
-To update the iOS SDK:
+To update the iOS SDK, edit `ios/rokt_sdk.podspec`:
 
-```yaml
-// ios/rokt_sdk.podspec
-s.version          = 'X.X.X'
-s.dependency 'Rokt-Widget', '~> X.X.X'
+```ruby
+s.dependency 'Rokt-Widget', '~> 5.3.0'
 ```
 
-For Android:
-
-It's currently using the latest snapshot of the development build from Maven Central.
-
-To update the SDK to a specific version:
+For Android, edit `android/build.gradle`:
 
 ```gradle
-// android/build.gradle
-implementation "com.rokt:roktsdk:X.X.X"
+implementation "com.rokt:roktsdk:6.0.1"
 ```
+
+See `CHANGELOG.md` for release notes when bumping native SDK versions.
 
 ### Gotchas
 
 - Always run `flutter clean` before updating the SDK version
+- Android apps must target API level 23+ to use this plugin (required by Rokt Android SDK 6.x)
 - For embedded placements, ensure the view is in the visible area of the screen before calling `selectPlacements`
 - To run in sandbox mode, add `"sandbox": "true"` to your attributes
-- When upgrading the native SDKs, you must update both the podspec version and the dependency version
+- When upgrading the native SDKs, update `android/build.gradle` and `ios/rokt_sdk.podspec`, then document changes in `CHANGELOG.md`
+- Shoppable Ads (`selectShoppableAds`, `registerPaymentExtension`) are iOS-only; Android calls are no-ops
 
 ## Making Changes and Deployment
 

--- a/README.md
+++ b/README.md
@@ -232,10 +232,10 @@ roktEventChannel.receiveBroadcastStream().listen((dynamic event) {
 
 This Flutter plugin bundles the following native SDK versions:
 
-| Platform | Native dependency | Version |
-| -------- | ----------------- | ------- |
-| Android  | `com.rokt:roktsdk` | 6.0.1 |
-| iOS      | `Rokt-Widget` | 5.3.0 |
+| Platform | Native dependency  | Version |
+| -------- | ------------------ | ------- |
+| Android  | `com.rokt:roktsdk` | 6.0.1   |
+| iOS      | `Rokt-Widget`      | 5.3.0   |
 
 ### Dependencies
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@ group 'com.rokt.rokt_sdk'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.9.10'
+    ext.kotlin_version = '2.1.20'
     repositories {
         google()
         mavenCentral()
@@ -53,13 +53,13 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 21 // using Hybrid composition
+        minSdkVersion 23 // required by Rokt Android SDK 6.x
         multiDexEnabled true
     }
 }
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation "com.rokt:roktsdk:5.1.0"
+    implementation "com.rokt:roktsdk:6.0.1"
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.6.1"
 }

--- a/example/Gemfile
+++ b/example/Gemfile
@@ -4,3 +4,4 @@ source "https://rubygems.org"
 
 gem "cocoapods" , '1.15.2'
 gem "rexml", "3.4.4"
+gem "concurrent-ruby", ">= 1.3.7"

--- a/example/Gemfile.lock
+++ b/example/Gemfile.lock
@@ -65,7 +65,7 @@ GEM
       netrc (~> 0.11)
     cocoapods-try (1.2.0)
     colored2 (3.1.2)
-    concurrent-ruby (1.3.5)
+    concurrent-ruby (1.3.7)
     connection_pool (2.5.0)
     drb (2.2.1)
     escape (0.0.4)
@@ -111,6 +111,7 @@ PLATFORMS
 
 DEPENDENCIES
   cocoapods (= 1.15.2)
+  concurrent-ruby (>= 1.3.7)
   rexml (= 3.4.4)
 
 BUNDLED WITH

--- a/example/integration_test/app_test.dart
+++ b/example/integration_test/app_test.dart
@@ -1,6 +1,6 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
-import 'package:flutter/material.dart';
 import 'package:rokt_sdk_example/main.dart' as app;
 
 void main() {
@@ -17,7 +17,7 @@ void main() {
 
       final Finder init = find.text('Initialize');
       await tester.tap(init);
-      await addDelay(3000);
+      await addDelay(5000);
       await tester.pumpAndSettle();
 
       final roktWidget1 = find.byKey(const ValueKey('widget1'));
@@ -26,16 +26,12 @@ void main() {
       final Finder selectPlacements = find.text('Select Placements');
       await tester.tap(selectPlacements);
 
-      // Add longer delay after selectPlacements to ensure placement is fully ready
-      await addDelay(8000);
-      await tester.pumpAndSettle();
+      final widget1Height = await pollWidgetHeight(
+        tester: tester,
+        widget: roktWidget1,
+        timeout: const Duration(seconds: 90),
+      );
 
-      // Add additional pump to ensure widget rebuilds
-      await tester.pump(const Duration(seconds: 2));
-      await tester.pumpAndSettle();
-
-      // Verify widget1 height
-      final widget1Height = tester.getSize(roktWidget1).height;
       // ignore: avoid_print
       print('Widget1 height after selectPlacements: $widget1Height');
       expect(widget1Height, greaterThan(2.0));
@@ -45,4 +41,20 @@ void main() {
 
 Future<void> addDelay(int ms) async {
   await Future<void>.delayed(Duration(milliseconds: ms));
+}
+
+Future<double> pollWidgetHeight({
+  required WidgetTester tester,
+  required Finder widget,
+  required Duration timeout,
+}) async {
+  final deadline = DateTime.now().add(timeout);
+  var height = tester.getSize(widget).height;
+
+  while (height <= 2.0 && DateTime.now().isBefore(deadline)) {
+    await tester.pump(const Duration(seconds: 1));
+    height = tester.getSize(widget).height;
+  }
+
+  return height;
 }

--- a/example/ios/Gemfile
+++ b/example/ios/Gemfile
@@ -2,3 +2,4 @@ source "https://rubygems.org"
 
 gem "cocoapods" , "1.15.2"
 gem "rexml", "3.4.4"
+gem "concurrent-ruby", ">= 1.3.7"

--- a/example/ios/Gemfile.lock
+++ b/example/ios/Gemfile.lock
@@ -65,7 +65,7 @@ GEM
       netrc (~> 0.11)
     cocoapods-try (1.2.0)
     colored2 (3.1.2)
-    concurrent-ruby (1.3.5)
+    concurrent-ruby (1.3.7)
     connection_pool (2.5.0)
     drb (2.2.1)
     escape (0.0.4)
@@ -111,6 +111,7 @@ PLATFORMS
 
 DEPENDENCIES
   cocoapods (= 1.15.2)
+  concurrent-ruby (>= 1.3.7)
   rexml (= 3.4.4)
 
 BUNDLED WITH

--- a/ios/rokt_sdk.podspec
+++ b/ios/rokt_sdk.podspec
@@ -15,7 +15,7 @@ Rokt Mobile SDK to integrate ROKT Api into Flutter application.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Rokt-Widget', '~> 5.2.1'
+  s.dependency 'Rokt-Widget', '~> 5.3.0'
   s.platform = :ios, '15.0'
   s.resource_bundles = { "Rokt-Widget" => ["PrivacyInfo.xcprivacy"] }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Background

- The Flutter plugin was pinned to older native SDK releases (iOS Rokt-Widget 5.2.1, Android com.rokt:roktsdk 5.1.0). Newer native versions are available — iOS 5.3.0 and Android 6.0.1 — with payment retry improvements, bug fixes, and Android 6.x toolchain requirements. This PR bumps those dependencies so integrators get current native behavior without Dart API changes.
- Android 6.x requires Kotlin 2.1.20+ and a minimum SDK of API 23. The plugin and README needed to reflect that so partner apps don’t hit build or runtime issues on older Android versions.

## What Has Changed

- Bumped iOS native dependency to Rokt-Widget ~> 5.3.0 in ios/rokt_sdk.podspec
- Bumped Android native dependency to com.rokt:roktsdk:6.0.1 in android/build.gradle
- Raised Android plugin minSdkVersion from 21 to 23 and Kotlin from 1.9.10 to 2.1.20 to satisfy Rokt Android SDK 6.x requirements
- Updated CHANGELOG.md under [Unreleased] with the native SDK version bump and minSdk change
- Aligned README.md with current integration requirements: native SDK version table, minSdk 23, Kotlin 2.1.20 / AGP 8.6.0 / Gradle 8.9, rokt_sdk: ^5.0.0, corrected Android/iOS dependency naming, updated Shoppable Ads payment extension setup to RoktPaymentExtension 2.0.3, and refreshed native SDK update instructions

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Reference Issue (For employees only. Ignore if you are an outside contributor)

- Closes [ticket](https://go/j/[ticket-number])
